### PR TITLE
Logic to deal with caps in image names

### DIFF
--- a/tools/prepare-image/linux-prepare-image
+++ b/tools/prepare-image/linux-prepare-image
@@ -206,15 +206,11 @@ PRODUCT_FILE=/etc/product
 if [[ ! -f $PRODUCT_FILE ]]; then
     fatal "Unknown Distribution...exiting"
 fi
-TARGET_DISTRO=`grep -w Image $PRODUCT_FILE | awk '{print $2;}'`
+TARGET_DISTRO=$(grep -w Image $PRODUCT_FILE | awk '{print $2;}' | tr '[:upper:]' '[:lower:]')
 
-# Subtlety: the "Image" line in /etc/product in old ubuntu images has
-# "ubuntu" (lowercase). In the new ubuntu-certified images it is "Ubuntu"
-# (uppercase).
 if [ $TARGET_DISTRO == "centos" ] ; then
     prepare_centos
 elif [[ $TARGET_DISTRO == "ubuntu" ||
-	$TARGET_DISTRO == "Ubuntu" ||
 	$TARGET_DISTRO == "debian" ]] ; then
     prepare_ubuntu
 fi


### PR DESCRIPTION
On newer images we switched to using proper caps for distro names in
the /etc/product file (e.g., "CentOS" instead of "centos" for example).
This change converts the image name to all lower case in oder to handle
any differences in capitalization of image name from one release to the
next.
