### PR TITLE
TRITON-2005 imgapi needs to stop using snaplinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /smf/manifests/imgapi.xml
 /etc/imgapi.config.json
 /imgapi-pkg-*.tar.gz
+.DS_Store

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
   temporary object path (`.../$uuid/file0.$req_id`) and then get linked to its
   final location (`.../$uuid/file0`). Now, for MantaStorage, it just writes
   directly to the final location. Manta semantics are such that a failed partial
-  write does *not* blow away an existing object alread at that location, which
+  write does *not* blow away an existing object already at that location, which
   was the original reason for that temporary path write.
 
   Endpoints affected by this change:

--- a/lib/images.js
+++ b/lib/images.js
@@ -2933,8 +2933,6 @@ function apiAddImageFileFromSource(req, res, next) {
         }
     }
 
-    var config = req._app.config;
-    var inclAdminFields = false;
     var uuid = req.params.uuid;
     var client = new sdcClients.IMGAPI(utils.commonHttpClientOpts({
         url: req.query.source,

--- a/lib/images.js
+++ b/lib/images.js
@@ -1712,20 +1712,6 @@ function apiListImages(req, res, next) {
 function apiGetImage(req, res, next) {
     var serialized = req._image.serialize(req._app.mode, req.getVersion(),
         req.inclAdminFields);
-
-    // TRITON-52 Include the manta details for this file.
-    if (req.inclAdminFields && req._image.files.length > 0 &&
-            req._image.files[0].stor === 'manta') {
-        var file = serialized.files[0];
-        var stor = req._app.getStor('manta');
-        if (stor && file) {
-            file.mantaPath = stor.storPathFromImageUuid(
-                req._image.uuid, 'file0');
-            file.mantaUrl = req._app.config.manta.url;
-            file.mantaUser = req._app.config.manta.user;
-        }
-    }
-
     resSetEtag(req, res, serialized);
     res.send(serialized);
     next();
@@ -2964,65 +2950,8 @@ function apiAddImageFileFromSource(req, res, next) {
     }
     next = closeClientAndCallNext;
 
-    // TRITON-52 Request file details for possible manta file snaplinking.
-    if (req._app.mode === 'dc' && config.imgapiUrlFromDatacenter &&
-        Object.keys(config.imgapiUrlFromDatacenter).some(
-            function _urlSome(datacenter) {
-                return config.imgapiUrlFromDatacenter[datacenter] ===
-                    req.query.source;
-            }
-        )) {
-        inclAdminFields = true;
-    }
-
     // Get the image so we can get the manifest file details.
-    client.getImage(uuid, {inclAdminFields: inclAdminFields},
-        addImageFileFromSharedMantaSource);
-
-    // TRITON-52 Check if the given IMGAPI source uses the same manta storage,
-    // if yes then the manta file can be snaplinked rather than bit-copied.
-    function addImageFileFromSharedMantaSource(err, manifest) {
-        if (err) {
-            req.log.error(err, 'apiAddImageFile: failed to get image %s',
-                uuid);
-            next(new errors.RemoteSourceError(format('Unable ' +
-                'to get manifest for image %s. Error from remote: %s',
-                uuid, err.message || err.code)));
-            return;
-        }
-
-        var file = manifest.files.length > 0 && manifest.files[0];
-
-        // The file must use the same Manta (same url, same user).
-        if (inclAdminFields && file && file.mantaPath &&
-                file.mantaUrl === config.manta.url &&
-                file.mantaUser === config.manta.user) {
-            var stor = req._app.getStor('manta');
-            if (!stor) {
-                addImageFileFromImgapiSource(manifest);
-                return;
-            }
-
-            // The image file can be manta snaplinked.
-            // Passing some vars onto `finishMoveImageFile`.
-            req.file = objCopy(file);
-            req.file.stor = stor.type;
-            req.storage = stor.type;
-
-            assert.string(req.file.mantaPath, 'req.file.mantaPath');
-            req.mantaSnaplinkPath = req.file.mantaPath;
-
-            // Remove these manta properties - we don't want that saved in the
-            // file metadata.
-            delete req.file.mantaPath;
-            delete req.file.mantaUrl;
-            delete req.file.mantaUser;
-
-            next();
-            return;
-        }
-        addImageFileFromImgapiSource(manifest);
-    }
+    client.getImage(uuid, addImageFileFromImgapiSource);
 
     function addImageFileFromImgapiSource(manifest) {
         var compression = manifest.files[0].compression;
@@ -3329,13 +3258,7 @@ function finishMoveImageFile(req, res, next) {
         function doMoveImageFile(_, cb) {
             var stor = req._app.getStor(req.storage);
             assert.object(stor, 'stor');
-            if (req.mantaSnaplinkPath) {
-                req.log.debug({uuid: req._image.uuid,
-                     mantaSnaplinkPath: req.mantaSnaplinkPath},
-                    'Snaplinking from existing manta file');
-                stor.snapLinkImageFileFromPath(req._image,
-                    req.mantaSnaplinkPath, cb);
-            } else if (req.tmpFilename) {
+            if (req.tmpFilename) {
                 assert.string(req.filename, 'req.filename');
                 assert.string(req.tmpFilename, 'req.tmpFilename');
                 stor.moveImageFile(req._image, req.tmpFilename, req.filename,

--- a/lib/images.js
+++ b/lib/images.js
@@ -3753,12 +3753,12 @@ function apiAdminChangeImageStor(req, res, cb) {
     var needToChange = (newStor.type !== curStor.type);
 
     vasync.pipeline({arg: {}, funcs: [
-        function copyItToTmp(ctx, next) {
+        function copyIt(ctx, next) {
             if (!needToChange) {
                 next();
                 return;
             }
-            log.trace('AdminChangeImageStor: copyItToTmp');
+            log.trace('AdminChangeImageStor: copyIt');
 
             curStor.createImageFileReadStream(image, 'file0', {},
                     function (rErr, rStream) {
@@ -3788,8 +3788,8 @@ function apiAdminChangeImageStor(req, res, cb) {
             });
         },
 
-        function moveToFinal(ctx, next) {
-            if (!needToChange) {
+        function moveToFinalIfNecessary(ctx, next) {
+            if (!needToChange || !ctx.tmpFileName) {
                 next();
                 return;
             }

--- a/lib/images.js
+++ b/lib/images.js
@@ -2951,7 +2951,16 @@ function apiAddImageFileFromSource(req, res, next) {
     // Get the image so we can get the manifest file details.
     client.getImage(uuid, addImageFileFromImgapiSource);
 
-    function addImageFileFromImgapiSource(manifest) {
+    function addImageFileFromImgapiSource(err, manifest) {
+        if (err) {
+            req.log.error(err, 'apiAddImageFile: failed to get image %s',
+                uuid);
+            next(new errors.RemoteSourceError(format('Unable ' +
+                'to get manifest for image %s. Error from remote: %s',
+                uuid, err.message || err.code)));
+            return;
+        }
+
         var compression = manifest.files[0].compression;
         var sha1Param = manifest.files[0].sha1;
         var contentLength = manifest.files[0].size;

--- a/lib/images.js
+++ b/lib/images.js
@@ -3309,7 +3309,7 @@ function apiAddImageFileFromUrl(req, res, next) {
 
 /**
  * Complete the AddImageFile[FromSource] endpoint by moving the image file
- * into its final (non-tmp) place.
+ * into its final (non-tmp) place, if a tmp storage location was used.
  */
 function finishMoveImageFile(req, res, next) {
     assert.object(req, 'req');
@@ -3319,14 +3319,14 @@ function finishMoveImageFile(req, res, next) {
     assert.object(res, 'res');
     assert.func(next, 'next');
 
-    req.log.debug({uuid: req._image.uuid}, 'FinishMoveImageFile: start');
+    req.log.debug({uuid: req._image.uuid}, 'finishMoveImageFile: start');
 
     if (req._image.activated) {
         return next(new errors.ImageAlreadyActivatedError(req._image.uuid));
     }
 
     vasync.pipeline({ funcs: [
-        function moveImageFile(_, cb) {
+        function doMoveImageFile(_, cb) {
             var stor = req._app.getStor(req.storage);
             assert.object(stor, 'stor');
             if (req.mantaSnaplinkPath) {
@@ -3335,11 +3335,14 @@ function finishMoveImageFile(req, res, next) {
                     'Snaplinking from existing manta file');
                 stor.snapLinkImageFileFromPath(req._image,
                     req.mantaSnaplinkPath, cb);
-            } else {
+            } else if (req.tmpFilename) {
                 assert.string(req.filename, 'req.filename');
                 assert.string(req.tmpFilename, 'req.tmpFilename');
                 stor.moveImageFile(req._image, req.tmpFilename, req.filename,
                     cb);
+            } else {
+                // File is already in its final `req.filename` location.
+                cb();
             }
         },
         function addImageFileDetails(_, cb) {
@@ -3359,7 +3362,7 @@ function finishMoveImageFile(req, res, next) {
             return;
         }
 
-        req.log.debug({uuid: req._image.uuid}, 'FinishMoveImageFile: success');
+        req.log.debug({uuid: req._image.uuid}, 'finishMoveImageFile: success');
 
         var serialized = req._image.serialize(req._app.mode, req.getVersion());
         resSetEtag(req, res, serialized);
@@ -3567,31 +3570,44 @@ function apiAddImageIcon(req, res, next) {
 
 /**
  * Complete the AddImageIcon endpoint by moving the image file
- * into its final (non-tmp) place.
+ * into its final (non-tmp) place, if a tmpFilename was used.
  */
 function finishMoveImageIcon(req, res, next) {
     req.log.debug({image: req._image}, 'MoveImageIcon: start');
 
-    var stor = req._app.getStor(req.storage);
-    stor.moveImageFile(req._image, req.tmpFilename, req.filename,
-      function (mErr) {
-        if (mErr) {
-            return next(mErr);
-        }
 
-        req._image.addIcon(req._app, req.icon, req.log, function (err2) {
-            if (err2) {
-                req.log.error(err2, 'error setting icon=true to Image');
-                return next(new errors.InternalError(err2,
-                    'could not save icon data'));
+    vasync.pipeline({
+        funcs: [
+            function doMoveImageFileIfNecessary(_, cb) {
+                if (!req.tmpFilename) {
+                    cb();
+                    return;
+                }
+
+                var stor = req._app.getStor(req.storage);
+                stor.moveImageFile(req._image, req.tmpFilename, req.filename,
+                    cb);
+            },
+
+            function addToImageObjectAndRespond(_, cb) {
+                req._image.addIcon(req._app, req.icon, req.log, function (err) {
+                    if (err) {
+                        req.log.error(err, 'error setting icon=true to Image');
+                        cb(new errors.InternalError(err,
+                            'could not save icon data'));
+                        return;
+                    }
+
+                    var serialized = req._image.serialize(req._app.mode,
+                            req.getVersion());
+                    resSetEtag(req, res, serialized);
+                    res.send(serialized);
+                    cb();
+                });
             }
-
-            var serialized = req._image.serialize(req._app.mode,
-                    req.getVersion());
-            resSetEtag(req, res, serialized);
-            res.send(serialized);
-            next();
-        });
+        ]
+    }, function finish(err) {
+        next(err);
     });
 }
 
@@ -4202,7 +4218,7 @@ function apiUpdateImage(req, res, cb) {
             }, next);
         },
 
-        function moveImageFile(ctx, next) {
+        function doMoveImageFile(ctx, next) {
             if (!ctx.uuidChanged) {
                 next();
                 return;

--- a/lib/images.js
+++ b/lib/images.js
@@ -3964,12 +3964,11 @@ function apiExportImage(req, res, callback) {
                     }
                 });
             },
-            function exportImageFile(next) {
-                stor.snapLinkImageFile(image, fileStorPath, function (sErr) {
-                    if (sErr) {
-                        log.error(sErr, 'error creating image file snaplink');
+            function exportFile(next) {
+                stor.exportImageFile(image, fileStorPath, function (err) {
+                    if (err) {
                         next(errors.parseErrorFromStorage(
-                            sErr, 'error creating image file snaplink'));
+                            err, 'error exporting image file'));
                     } else {
                         next();
                     }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -738,15 +738,34 @@ function (string, storPath, callback) {
     stream.end(string);
 };
 
-MantaStorage.prototype.snapLinkImageFile =
-function snapLinkImageFile(image, toPath, callback) {
+MantaStorage.prototype.exportImageFile = function (image, toPath, callback) {
     assert.object(image, 'image');
-    assert.string(image.uuid, 'image.uuid');
-    assert.string(toPath, 'toPath');
-    assert.func(callback, 'callback');
+    assert.uuid(image.uuid, 'image.uuid');
+    assert.object(image.files[0], 'image.files[0]');
 
-    var fromPath = this.storPathFromImageUuid(image.uuid, 'file0');
-    this.client.ln(fromPath, toPath, callback);
+    var self = this;
+    var fromPath = self.storPathFromImageUuid(image.uuid, 'file0');
+    var putOpts = {
+        type: 'application/octet-stream',
+        md5: image.files[0].contentMD5,
+        size: image.files[0].size
+    };
+
+    self.client.get(fromPath, function (getErr, getStream, res) {
+        if (getErr) {
+            callback(getErr);
+            return;
+        }
+
+        self.client.put(toPath, getStream, putOpts, function onPut(putErr) {
+            if (putErr) {
+                callback(putErr);
+                return;
+            }
+
+            callback();
+        });
+    });
 };
 
 MantaStorage.prototype.snapLinkImageFileFromPath =

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -95,10 +95,13 @@ Storage.prototype.deleteImageFile =
  * a higher level function for storage backends that take an input stream as an
  * argument (manta's put()).
  *
- * This function is typically used together with `moveImageFile`:
+ * For the "local" storage type, this function is used together with
+ * `moveImageFile`:
  * 1. `storeFileFromStream` will write to a temporary file name (which
  *    includes the given reqId to avoid two requests overwriting each other)
  * 2. `moveImageFile` will move from the `tmpFilename` to the final `filename`.
+ *
+ * For the "manta" storage type no temporary filename is used.
  *
  * @param opts {Object}
  *      - @param image {Image}
@@ -117,6 +120,9 @@ Storage.prototype.deleteImageFile =
  *        Per HTTP spec this is the *base64* digest of the MD5 checksum. If
  *        provided, this will be checked on upload.
  * @param callback {Function} `function (err, tmpFilename, filename)`
+ *      If `tmpFilename` is set, then this has written the file to a temporary
+ *      filename. The caller should then follow up with a `.moveImageFile(...)`
+ *      call to move the image file to the final `filename` path.
  */
 Storage.prototype.storeFileFromStream =
     function storeFileFromStream(opts, callback) {
@@ -124,9 +130,8 @@ Storage.prototype.storeFileFromStream =
 
 /**
  * Moves an image file from source to destination. This function is used
- * after `storeFileFromStream` to move a tmp file to its final destination.
- * If the tmp file was not uploaded correctly we won't overwrite a previous
- * working copy of an image file.
+ * after `storeFileFromStream` to move a tmp file to its final destination,
+ * if a `tmpFilename` was used.
  *
  * @param image {Image}
  * @param from {String} Source filename
@@ -312,6 +317,15 @@ LocalStorage.prototype.deleteImageFile = function (image, filename, callback) {
     });
 };
 
+
+/*
+ * This writes the file stream to a temporary filename so that if tmp file is
+ * not uploaded correctly we won't overwrite a previous working copy of
+ * an image file.
+ *
+ * The caller is expected to call `stor.moveImageFile(...)` after to complete
+ * the process of storing the file.
+ */
 LocalStorage.prototype.storeFileFromStream =
         function localStoreFileFromStream(opts, callback) {
     assert.object(opts, 'opts');
@@ -443,7 +457,6 @@ LocalStorage.prototype.storeFileFromFile =
         });
     });
 };
-
 
 LocalStorage.prototype.moveImageFile = function (image, from, to, callback) {
     assert.object(image, 'image');
@@ -667,6 +680,11 @@ MantaStorage.prototype.createImageFileWriteStream =
 };
 
 
+/*
+ * Note: Unlike the `storeFileFromStream` implementation for "local" storage,
+ * this does not use a temporary filename. Manta semantics already avoid a
+ * failed upload overwriting an already existing file at the same path.
+ */
 MantaStorage.prototype.storeFileFromStream =
         function mantaStoreFileFromStream(opts, callback) {
     assert.object(opts, 'opts');
@@ -680,9 +698,8 @@ MantaStorage.prototype.storeFileFromStream =
     assert.func(callback, 'callback');
 
     var self = this;
-    var tmpFilename = format('%s.%s', opts.filename, opts.reqId);
 
-    self.createImageFileWriteStream(opts.image, tmpFilename,
+    self.createImageFileWriteStream(opts.image, opts.filename,
             function (sErr, aPath) {
         if (sErr) {
             onFileWriteStream(sErr);
@@ -702,7 +719,7 @@ MantaStorage.prototype.storeFileFromStream =
             return;
         }
 
-        return callback(null, tmpFilename, opts.filename);
+        return callback(null, null, opts.filename);
     }
 };
 
@@ -722,7 +739,7 @@ function (string, storPath, callback) {
 };
 
 MantaStorage.prototype.snapLinkImageFile =
-function (image, toPath, callback) {
+function snapLinkImageFile(image, toPath, callback) {
     assert.object(image, 'image');
     assert.string(image.uuid, 'image.uuid');
     assert.string(toPath, 'toPath');
@@ -822,29 +839,9 @@ MantaStorage.prototype.deleteImageFile =
 };
 
 
-MantaStorage.prototype.moveImageFile = function (image, from, to, callback) {
-    assert.object(image, 'image');
-    assert.string(image.uuid, 'image.uuid');
-    assert.string(from, 'from');
-    assert.string(to, 'from');
-    assert.func(callback, 'callback');
-
-    var fromPath = this.storPathFromImageUuid(image.uuid, from);
-    var toPath = this.storPathFromImageUuid(image.uuid, to);
-
-    var self = this;
-    self.client.ln(fromPath, toPath, function (err) {
-        if (err) {
-            return callback(err);
-        }
-
-        self.deleteImageFile(image, from, function (delErr) {
-            if (delErr) {
-                return callback(delErr);
-            }
-            return callback();
-        });
-    });
+MantaStorage.prototype.moveImageFile =
+function mantaMoveImageFile(image, from, to, callback) {
+    throw Error('"moveImageFile" is not implemented for "manta" storage');
 };
 
 MantaStorage.prototype.moveFileBetweenImages =

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -768,26 +768,6 @@ MantaStorage.prototype.exportImageFile = function (image, toPath, callback) {
     });
 };
 
-MantaStorage.prototype.snapLinkImageFileFromPath =
-function (image, fromPath, callback) {
-    assert.object(image, 'image');
-    assert.string(image.uuid, 'image.uuid');
-    assert.string(fromPath, 'fromPath');
-    assert.func(callback, 'callback');
-
-    var self = this;
-    var toPath = this.storPathFromImageUuid(image.uuid, 'file0');
-    var toDir = path.dirname(toPath);
-
-    self.client.mkdirp(toDir, function _snapLinkMkdirpCb(err) {
-        if (err) {
-            callback(err);
-            return;
-        }
-        self.client.ln(fromPath, toPath, callback);
-    });
-};
-
 MantaStorage.prototype.createImageFileReadStream =
         function (image, filename, opts, callback) {
     assert.object(image, 'image');

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -880,7 +880,8 @@ function moveFileBetweenImages(fromImage, toImage, filename, callback) {
     var putOpts = {
         type: 'application/octet-stream',
         md5: fromImage.files[0].contentMD5,
-        size: fromImage.files[0].size
+        size: fromImage.files[0].size,
+        mkdirs: true
     };
 
     self.client.get(fromPath, function (getErr, getStream, res) {
@@ -911,22 +912,36 @@ MantaStorage.prototype.copyFileBetweenImages =
 function mantaCopyFileBetweenImages(fromImage, toImage, filename, callback) {
     assert.object(fromImage, 'fromImage');
     assert.uuid(fromImage.uuid, 'fromImage.uuid');
+    assert.object(fromImage.files[0], 'fromImage.files[0]');
     assert.object(toImage, 'toImage');
     assert.uuid(toImage.uuid, 'toImage.uuid');
     assert.string(filename, 'filename');
     assert.func(callback, 'callback');
 
-    var fromPath = this.storPathFromImageUuid(fromImage.uuid, filename);
-    var toPath = this.storPathFromImageUuid(toImage.uuid, filename);
-    var toDir = path.dirname(toPath);
-
     var self = this;
+    var fromPath = self.storPathFromImageUuid(fromImage.uuid, filename);
+    var toPath = self.storPathFromImageUuid(toImage.uuid, filename);
+    var putOpts = {
+        type: 'application/octet-stream',
+        md5: fromImage.files[0].contentMD5,
+        size: fromImage.files[0].size,
+        mkdirs: true
+    };
 
-    self.client.mkdirp(toDir, function _mantaCopyFileMkdirpCb(mkdirErr) {
-        if (mkdirErr) {
-            return callback(mkdirErr);
+    self.client.get(fromPath, function (getErr, getStream, res) {
+        if (getErr) {
+            callback(getErr);
+            return;
         }
-        self.client.ln(fromPath, toPath, callback);
+
+        self.client.put(toPath, getStream, putOpts, function onPut(putErr) {
+            if (putErr) {
+                callback(putErr);
+                return;
+            }
+
+            callback();
+        });
     });
 };
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -860,38 +860,48 @@ MantaStorage.prototype.deleteImageFile =
 
 MantaStorage.prototype.moveImageFile =
 function mantaMoveImageFile(image, from, to, callback) {
-    throw Error('"moveImageFile" is not implemented for "manta" storage');
+    callback(new Error(
+        '"moveImageFile" is not implemented for "manta" storage'));
 };
 
 MantaStorage.prototype.moveFileBetweenImages =
 function moveFileBetweenImages(fromImage, toImage, filename, callback) {
     assert.object(fromImage, 'fromImage');
     assert.uuid(fromImage.uuid, 'fromImage.uuid');
+    assert.object(fromImage.files[0], 'fromImage.files[0]');
     assert.object(toImage, 'toImage');
     assert.uuid(toImage.uuid, 'toImage.uuid');
     assert.string(filename, 'filename');
     assert.func(callback, 'callback');
 
-    var fromPath = this.storPathFromImageUuid(fromImage.uuid, filename);
-    var toPath = this.storPathFromImageUuid(toImage.uuid, filename);
-    var toDir = path.dirname(toPath);
-
     var self = this;
+    var fromPath = self.storPathFromImageUuid(fromImage.uuid, filename);
+    var toPath = self.storPathFromImageUuid(toImage.uuid, filename);
+    var putOpts = {
+        type: 'application/octet-stream',
+        md5: fromImage.files[0].contentMD5,
+        size: fromImage.files[0].size
+    };
 
-    self.client.mkdirp(toDir, function (mkdirErr) {
-        if (mkdirErr) {
-            return callback(mkdirErr);
+    self.client.get(fromPath, function (getErr, getStream, res) {
+        if (getErr) {
+            callback(getErr);
+            return;
         }
-        self.client.ln(fromPath, toPath, function (err) {
-            if (err) {
-                return callback(err);
+
+        self.client.put(toPath, getStream, putOpts, function onPut(putErr) {
+            if (putErr) {
+                callback(putErr);
+                return;
             }
 
             self.deleteImageFile(fromImage, filename, function (delErr) {
                 if (delErr) {
-                    return callback(delErr);
+                    callback(delErr);
+                    return;
                 }
-                return callback();
+
+                callback();
             });
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "imgapi",
   "description": "Image API to manage images for Triton Data Center",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
There were a number of IMGAPI endpoints that would use snaplinks for moving
image files around for those that were stored in Manta (non-admin-owned images 
in an IMGAPI configured to use a Manta). These have been changed to instead
stream the file out and stream the file back into Manta at the wanted path.

The one exception to that change is ImportImage: This *used* to write a
temporary object path (.../$uuid/file0.$req_id) and then get linked to its
final location (.../$uuid/file0). Now, for MantaStorage, it just writes
directly to the final location. Manta semantics are such that a failed partial
write does *not* blow away an existing object alread at that location, which
was the original reason for that temporary path write.

Endpoints affected by this change
- AddImageFile (used by typical 'sdc-imgadm import ...' commands)
- AddImageFileFromUrl
- UpdateImage (when changing the UUID, as used only by 'docker build')
- CloneImage ('triton image clone ...')
- ImportFromDatacenter ('triton image copy ...')
- AdminChangeImageStor ('sdc-imgadm change-stor ...')
- ExportImage ('triton image export ...')
- AddImageIcon