### PR TITLE
TRITON-2207 Update services to fix node-artedi#16 label values not escaped properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "imgapi",
   "description": "Image API to manage images for Triton Data Center",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {
@@ -40,7 +40,7 @@
     "sshpk": "1.13.0",
     "through2": "2.0.3",
     "trace-event": "1.2.0",
-    "triton-metrics": "0.1.1",
+    "triton-metrics": "1.0.3",
     "ufds": "1.2.0",
     "uuid": "2.0.2",
     "vasync": "1.6.3",


### PR DESCRIPTION
This is a public facing service that needs to be updated. Note that although Triton's imgapi is firewalled so that the external interface isn't accessible, standalone imgapi instances are also used for public image servers.